### PR TITLE
Add example of velero backup for daemonset and configmap

### DIFF
--- a/kubernetes/cray-precache-images/Chart.yaml
+++ b/kubernetes/cray-precache-images/Chart.yaml
@@ -4,4 +4,4 @@
 apiVersion: v1
 name: cray-precache-images
 description: Cache nexus and other images across worker nodes
-version: 0.3.0
+version: 0.4.0

--- a/kubernetes/cray-precache-images/templates/configmap.yaml
+++ b/kubernetes/cray-precache-images/templates/configmap.yaml
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cray-precache-images
+  labels:
+    app.kubernetes.io/name: {{ include "cray-precache-images.name" . }}
 data:
   images_to_cache: |-
     {{- range $image := .Values.cacheImages }}

--- a/kubernetes/cray-precache-images/templates/velero-backup.yaml
+++ b/kubernetes/cray-precache-images/templates/velero-backup.yaml
@@ -1,0 +1,19 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: cray-precache-images-daily-backup
+  namespace: velero
+spec:
+  schedule: 0 2 * * *
+  template:
+    includeClusterResources: true
+    includedNamespaces:
+    - nexus
+    includedResources:
+    - daemonset
+    - pod
+    - configmap
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: cray-precache-images
+    storageLocation: default


### PR DESCRIPTION
DO NOT MERGE THIS  -- JUST AN EXAMPLE

NOTES:

- All resources being backed up must have a label (specified in the Schedule).
- If backing up persistentvolumes and persistentvolumeclaims, an additional volume label is required (see example below).
- When restoring, must first delete all the entities first that velero is going to restore.

After deploying, see the backups with:

```
ncn-m001-95487181:/home/bklein # velero backup get | grep cache
cray-precache-images-daily-backup-20211109221906   Completed   0        0          2021-11-09 22:19:06 +0000 UTC   29d       default            app.kubernetes.io/name=cray-precache-images
cray-precache-images-daily-backup-20211109221639   Completed   0        0          2021-11-09 22:16:39 +0000 UTC   29d       default            app.kubernetes.io/name=cray-precache-images
```

To restore, first delete the entities being restored (daemonset and configmap):

```
kubectl delete -n nexus daemonset.apps/cray-precache-images
kubectl delete -n nexus configmap/cray-precache-images
```

Then restore:

```
velero restore create --from-backup cray-precache-images-daily-backup-20211109221906
```

And pods and config map are restored:

```
NAME                             READY   STATUS    RESTARTS   AGE
pod/cray-precache-images-7dhrd   1/1     Running   0          3m40s
pod/cray-precache-images-fcjnm   1/1     Running   0          3m40s
pod/cray-precache-images-gcd97   1/1     Running   0          3m39s
pod/cray-precache-images-ks269   1/1     Running   0          3m40s
pod/cray-precache-images-lp52t   1/1     Running   0          3m39s
pod/cray-precache-images-lxdgl   1/1     Running   0          3m39s

NAME                             DATA   AGE
configmap/cray-precache-images   3      3m40s
```

If persistentvolume and persistentvolumeclaim are to be included in a backup -- must also have the following velero annotation (`backup.velero.io/backup-volumes: <volume-name>`) with the volume name specified:

```
---

kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: test-pvc
  namespace: backups
  labels:
    app: test
  annotations:
    backup.velero.io/backup-volumes: pvc
spec:
  storageClassName: k8s-block-replicated
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 2Gi
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  namespace: backups
  labels:
    app: test
spec:
  selector:
    matchLabels:
      app: test
  replicas: 1
  template:
    metadata:
      annotations:
        backup.velero.io/backup-volumes: pvc
      labels:
        app: test
    spec:
      containers:
      - name: test
        image: registry.local/library/busybox:1.28.0-glibc
        command: ["sleep", "60000"]
        volumeMounts:
        - name: pvc
          mountPath: /data
          readOnly: false
      volumes:
      - name: pvc
        persistentVolumeClaim:
          claimName: test-pvc
```