### PR TITLE
Point to locally built alpine image, fix upgrade issue for configmap

### DIFF
--- a/charts/cray-precache-images/Chart.yaml
+++ b/charts/cray-precache-images/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-precache-images
-version: 0.5.0
+version: 0.5.1
 description: Cache nexus and other images across worker nodes
 keywords:
   - precache-images
@@ -42,7 +42,7 @@ annotations:
           url: https://github.com/Cray-HPE/cray-precache-images/pull/3
   artifacthub.io/images: |
     - name: alpine
-      image: alpine:3.14
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15
     - name: docker-kubectl
       image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
   artifacthub.io/license: MIT

--- a/charts/cray-precache-images/templates/daemonset.yaml
+++ b/charts/cray-precache-images/templates/daemonset.yaml
@@ -43,6 +43,7 @@ spec:
       annotations:
         {{- include "cray-precache-images.pod-annotations" . | nindent 8 }}
         sidecar.istio.io/inject: "false"
+        releaseTime: {{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC"| quote }}
     spec:
       containers:
       - name: cache-images

--- a/charts/cray-precache-images/templates/rbac.yaml
+++ b/charts/cray-precache-images/templates/rbac.yaml
@@ -34,7 +34,7 @@ metadata:
 rules:
 - apiGroups: ["apps"]
   resources: ["daemonsets"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cray-precache-images/templates/wait-jobs.yaml
+++ b/charts/cray-precache-images/templates/wait-jobs.yaml
@@ -51,7 +51,7 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - 'SLEEP=10; ITER=90; for i in `seq 1 $ITER`; do NEED_CNT=$(kubectl get daemonset -n $MY_POD_NAMESPACE cray-precache-images -o json | jq ".status.currentNumberScheduled"); READY_CNT=$(kubectl get daemonset -n $MY_POD_NAMESPACE cray-precache-images -o json | jq ".status.numberReady"); [ "$READY_CNT" -eq "$NEED_CNT" ] && break; echo "[Attempt:${i}] Waiting for cray-precache-images pods to be RUNNING (${READY_CNT}/${NEED_CNT}), sleeping $SLEEP seconds."; sleep $SLEEP; done; echo "*** cray-precache-images PODS RUNNING ***"'
+            - kubectl rollout status daemonset -n $MY_POD_NAMESPACE cray-precache-images
           env:
             - name: MY_POD_NAMESPACE
               valueFrom:

--- a/charts/cray-precache-images/values.yaml
+++ b/charts/cray-precache-images/values.yaml
@@ -36,8 +36,8 @@ fullnameOverride: ""
 podAnnotations: {}
 
 image:
-  repository: alpine
-  tag: 3.14
+  repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
+  tag: 3.15
   pullPolicy: IfNotPresent
 
 # Needed for wait-for job


### PR DESCRIPTION
## Summary and Scope

Fix alpine image for cray-precache-images chart, force pod restarts on upgrade, and fix wait-for job.

## Issues and Related PRs

* Resolves [CASMINST-4568](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4568)

## Testing

```
ncn-m001-fec36008:/home/bklein # kubectl logs -n nexus pod/wait-for-cray-precache-images-pods-m898g -f
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 of 6 updated pods are available...
daemon set "cray-precache-images" successfully rolled out
```

### Tested on:

  * Virtual Shasta

### Test description:

Tested multiple upgrades in vshasta, watched the wait job wait for pods to recycle, saw configmap updated with new values.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

