### PR TITLE
Change upgrade strategy to restart precache pods in parallel

### DIFF
--- a/charts/cray-precache-images/Chart.yaml
+++ b/charts/cray-precache-images/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-precache-images
-version: 0.5.1
+version: 0.5.2
 description: Cache nexus and other images across worker nodes
 keywords:
   - precache-images

--- a/charts/cray-precache-images/templates/daemonset.yaml
+++ b/charts/cray-precache-images/templates/daemonset.yaml
@@ -35,6 +35,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "cray-precache-images.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary and Scope

Change upgrade strategy to restart pods in the daemonset in parallel.  This isn't an api or db service, so they can all be restarted together.

## Issues and Related PRs

* Resolves [CASMPET-6052](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6052)

## Testing

Before:

```
ncn-m001-cdd6e862:/home/bklein # time kubectl rollout status daemonset -n nexus cray-precache-images
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 of 6 updated pods are available...
daemon set "cray-precache-images" successfully rolled out

real	4m10.543s
user	0m0.223s
sys	0m0.081s
```

After:

```
ncn-m001-cdd6e862:/home/bklein # time kubectl rollout status daemonset -n nexus cray-precache-images
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 of 6 updated pods are available...
daemon set "cray-precache-images" successfully rolled out

real	0m38.081s
user	0m0.222s
sys	0m0.040s
```

### Tested on:

  * Virtual Shasta

### Test description:

Multiple upgrades

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

