### PR TITLE
CASMPET-7912 use crictl container image for cray-precache-images for k8s 1.24

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -14,6 +14,7 @@ jobs:
       lint-charts: ${{ github.event_name == 'pull_request' }}
       test-charts: false
       scan-chart-snyk-args: "--severity-threshold=high"
+      scan-image-snyk-args: "--severity-threshold=critical"
     secrets:
       snyk-token: ${{ secrets.SNYK_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		cray-precache-images
 
 package:

--- a/charts/cray-precache-images/Chart.yaml
+++ b/charts/cray-precache-images/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-precache-images
-version: 0.5.2
+version: 0.6.0
 description: Cache nexus and other images across worker nodes
 keywords:
   - precache-images
@@ -41,8 +41,8 @@ annotations:
         - name: Github PR
           url: https://github.com/Cray-HPE/cray-precache-images/pull/3
   artifacthub.io/images: |
-    - name: alpine
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15
+    - name: cri-tools
+      image: artifactory.algol60.net/csm-docker/stable/github.com/kubernetes-sigs/cri-tools:v1.24.2
     - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
   artifacthub.io/license: MIT

--- a/charts/cray-precache-images/templates/daemonset.yaml
+++ b/charts/cray-precache-images/templates/daemonset.yaml
@@ -58,20 +58,16 @@ spec:
            - -c
            - "while true; do echo $(date -u); /scripts/cache_images.sh; echo ''; sleep $(cat /scripts/cache_refresh_seconds); done"
         volumeMounts:
-        - name: crictl
-          mountPath: /usr/local/bin
         - name: cache-images-script
           mountPath: /scripts
-        - name: containerd
-          mountPath: /var/run
+        - name: crictl-sock
+          mountPath: /run/containerd/containerd.sock
       volumes:
-      - name: crictl
-        hostPath:
-          path: /usr/local/bin
       - name: cache-images-script
         configMap:
           name: cray-precache-images
           defaultMode: 0744
-      - name: containerd
+      - name: crictl-sock
         hostPath:
-          path: /var/run
+          path: /run/containerd/containerd.sock
+          type: Socket

--- a/charts/cray-precache-images/values.yaml
+++ b/charts/cray-precache-images/values.yaml
@@ -36,13 +36,13 @@ fullnameOverride: ""
 podAnnotations: {}
 
 image:
-  repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
-  tag: 3.15
+  repository: artifactory.algol60.net/csm-docker/stable/github.com/kubernetes-sigs/cri-tools
+  tag: v1.24.2
   pullPolicy: IfNotPresent
 
 # Needed for wait-for job
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

Have cray-precached-images use github.com/kubernetes-sigs/cri-tools:v1.24.2 container image. This is a container image with 'crictl'.

This container image is necessary in CSM 1.6 because in the K8s 1.24/SLES 15 SP6 build, cray-precache-images no longer works. The cray-precached-images container is not able to access the crictl binary on the host. This container image means that the cray-precached-images container won't need to access the crictl on the host.

## Issues and Related PRs

* Resolves [CASMPET-7912](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7912)
* Resolves [CASMTRIAGE-7227](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7227)

## Testing

 * Fanta with SP6 and k8s 1.24

### Test description:

Upgraded the cray-precached-images chart and saw that images were able to be pulled.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

